### PR TITLE
fix(build)! Update base image from stretch (v9) to bullseye (v11)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # - ksh
 # - zsh
 # - fish
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 
 # Some metadata.
 MAINTAINER Dave Kerr <github.com/dwmkerr>


### PR DESCRIPTION
Fixes[1]

Possible BREAKING CHANGE

I don't know for sure this is a breaking change, but it jumps forward two major Debian versions so anyone using this should treat it as such 

Builds correctly:
```
[+] Building 103.3s (17/17) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                      0.1s 
 => => transferring dockerfile: 976B                                                                                                                                      0.1s 
 => [internal] load .dockerignore                                                                                                                                         0.0s 
 => => transferring context: 2B                                                                                                                                           0.0s 
 => [internal] load metadata for docker.io/library/debian:bullseye-slim                                                                                                   1.9s 
 => [auth] library/debian:pull token for registry-1.docker.io                                                                                                             0.0s 
 => CACHED [ 1/11] FROM docker.io/library/debian:bullseye-slim@sha256:f4da3f9b18fc242b739807a0fb3e77747f644f2fb3f67f4403fafce2286b431a                                    0.0s 
 => [internal] load build context                                                                                                                                         0.0s 
 => => transferring context: 105B                                                                                                                                         0.0s 
 => [ 2/11] RUN apt-get update -y                                                                                                                                         9.2s 
 => [ 3/11] RUN apt-get install -y psmisc                                                                                                                                 2.5s 
 => [ 4/11] RUN apt-get install -y make gcc                                                                                                                              50.2s 
 => [ 5/11] RUN apt-get install -y     csh     tcsh     ksh     zsh     fish     ash     dash                                                                            33.1s 
 => [ 6/11] COPY ./test/test.sh ./test.sh                                                                                                                                 0.0s 
 => [ 7/11] RUN chmod +x ./test.sh                                                                                                                                        0.6s 
 => [ 8/11] COPY heirloom-sh-050706.tar.bz2 /tmp/heirloom-sh-050706.tar.bz2                                                                                               0.0s 
 => [ 9/11] RUN tar -jxvf /tmp/heirloom-sh-050706.tar.bz2 -C /tmp/                                                                                                        0.6s 
 => [10/11] RUN cd /tmp/heirloom-sh-050706 && make                                                                                                                        2.6s 
 => [11/11] RUN cp /tmp/heirloom-sh-050706/sh /bin/heirloom-sh                                                                                                            0.5s 
 => exporting to image                                                                                                                                                    1.8s 
 => => exporting layers                                                                                                                                                   1.7s 
 => => writing image sha256:cf75179f982e3e13fced391e93972a904283e0b1fd00088ae74de746b579314f                                                                              0.0s
 => => naming to docker.io/library/dwmkerr-shells  
```